### PR TITLE
Use correct frame name in pixel perfect hit test

### DIFF
--- a/src/input/CreatePixelPerfectHandler.js
+++ b/src/input/CreatePixelPerfectHandler.js
@@ -21,7 +21,7 @@ var CreatePixelPerfectHandler = function (textureManager, alphaTolerance)
 {
     return function (hitArea, x, y, gameObject)
     {
-        var alpha = textureManager.getPixelAlpha(x, y, gameObject.texture.key, gameObject.frame.key);
+        var alpha = textureManager.getPixelAlpha(x, y, gameObject.texture.key, gameObject.frame.name);
 
         return (alpha && alpha >= alphaTolerance);
     };


### PR DESCRIPTION
`gameObject.frame.key` doesn't exist and was passing an undefined value to `getPixelAlpha`. This just changes it to the correct `gameObject.frame.name` value.